### PR TITLE
Ensure insight titles reflect chart view context

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,6 +155,52 @@ def _descriptive_chart_title(
     return f"{base} — {suffix}"
 
 
+def _augment_data_card(
+    data_card: Dict[str, Any],
+    chart_type: str,
+    short_delta: Optional[str],
+    source_df: Optional[pd.DataFrame] = None,
+) -> None:
+    """Attach view metadata so prompts/titles stay view-aware."""
+
+    view = {'A2': 'trend', 'A3': 'composition', 'A4': 'delta'}.get(chart_type)
+    if view:
+        data_card['view'] = view
+
+    if chart_type == 'A4':
+        if short_delta:
+            data_card['delta_type'] = short_delta.upper()
+    elif chart_type == 'A3':
+        split_col: Optional[str] = None
+        if source_df is not None:
+            tier_cols = extract_tier_columns(source_df)
+            if tier_cols:
+                split_col = tier_cols[0]
+            elif 'score_curr_tier' in source_df.columns:
+                split_col = 'score_curr_tier'
+            elif 'score_tier' in source_df.columns:
+                split_col = 'score_tier'
+        if split_col:
+            data_card['split_by'] = split_col
+
+
+def _needs_view_tag(title: str, chart_type: str, short_delta: Optional[str]) -> bool:
+    text = (title or '').lower()
+    if chart_type == 'A2':
+        return not any(token in text for token in ('trend', 'over time'))
+    if chart_type == 'A3':
+        return not any(token in text for token in ('tier', 'mix', 'composition'))
+    if chart_type == 'A4':
+        delta = (short_delta or '').lower()
+        if delta == 'qoq':
+            tags = ('qoq', 'quarter-over-quarter', 'q/q')
+        elif delta == 'yoy':
+            tags = ('yoy', 'year-over-year', 'y/y')
+        else:
+            tags = ('period-over-period', 'change', 'delta')
+        return not any(token in text for token in tags)
+    return False
+
 
 def _focus_suffix_from_period(period: Optional[str]) -> Optional[str]:
     """Return a canonical focus suffix (e.g., 'Q2') from a period label."""
@@ -1158,7 +1204,8 @@ def process_topic(topic: str,
                     composition_base = select_composition_base(src_df, metric)
                 
                 data_card = build_data_card(src_df, metric, chart_type, composition_base=composition_base)
-                
+                _augment_data_card(data_card, chart_type, short_delta, src_df)
+
                 # Generate narrative
                 narrative = llm_narrate(data_card, config)
                 results['narratives_generated'] += 1
@@ -1326,6 +1373,15 @@ def process_topic(topic: str,
                             (family_resolution or {}).get('granularity', 'quarterly').lower()
                             == 'quarterly'
                         )
+                        desc_focus = focus_upper if (periodic_enabled and focus_upper and is_quarterly) else None
+                        desc_title = _descriptive_chart_title(
+                            metric,
+                            chart_type,
+                            short_delta,
+                            desc_focus,
+                        )
+                        if _needs_view_tag(insight_title, chart_type, short_delta):
+                            insight_title = f"{desc_title} — {insight_title}" if insight_title else desc_title
 
                         if group_lower.startswith('delinquen'):
                             # Handle delinquency charts as a special group: build
@@ -1410,6 +1466,7 @@ def process_topic(topic: str,
                                 )
                                 trend_chart_title = f"{base_phrase} Trend"
                                 trend_card = build_data_card(prepared_trend, avail[0], 'A2')
+                                _augment_data_card(trend_card, 'A2', short_delta, prepared_trend)
                                 trend_narrative = llm_narrate(trend_card, config)
                                 add_chart_slide(
                                     presentation,
@@ -1464,6 +1521,7 @@ def process_topic(topic: str,
                                     'A3',
                                     composition_base='credit_tier',
                                 )
+                                _augment_data_card(severity_card, 'A3', short_delta, latest_df)
                                 severity_narrative = llm_narrate(severity_card, config)
                                 add_chart_slide(
                                     presentation,
@@ -1705,6 +1763,17 @@ def process_topic(topic: str,
                             insight_title = sanitized_title
                         else:
                             insight_title = 'Key Insight'
+                    desc_focus = None
+                    if 'focus_upper' in locals() and focus_upper and 'periodic_enabled' in locals() and periodic_enabled and 'is_quarterly' in locals() and is_quarterly:
+                        desc_focus = focus_upper
+                    desc_title = _descriptive_chart_title(
+                        metric,
+                        chart_type,
+                        short_delta,
+                        desc_focus,
+                    )
+                    if _needs_view_tag(insight_title, chart_type, short_delta):
+                        insight_title = f"{desc_title} — {insight_title}" if insight_title else desc_title
                     add_insight_slide(
                         presentation,
                         insight_title,
@@ -1787,6 +1856,7 @@ def process_topic(topic: str,
                         ctx.add_figure(figure_data, yoy_chart_type)
 
                         data_card2 = build_data_card(src_df, metric, yoy_chart_type)
+                        _augment_data_card(data_card2, yoy_chart_type, 'yoy', src_df)
                         narrative2 = llm_narrate(data_card2, config)
 
                         # Compute headline for YoY
@@ -1872,6 +1942,17 @@ def process_topic(topic: str,
                                                     delta_type,
                                                     focus_upper if 'focus_upper' in locals() else None,
                                                 )
+                                        desc_focus2 = None
+                                        if 'focus_upper' in locals() and focus_upper and 'periodic_enabled' in locals() and periodic_enabled and 'is_quarterly' in locals() and is_quarterly:
+                                            desc_focus2 = focus_upper
+                                        desc_title2 = _descriptive_chart_title(
+                                            metric,
+                                            yoy_chart_type,
+                                            delta_type,
+                                            desc_focus2,
+                                        )
+                                        if _needs_view_tag(insight_title2, yoy_chart_type, delta_type):
+                                            insight_title2 = f"{desc_title2} — {insight_title2}" if insight_title2 else desc_title2
                                         add_insight_slide(
                                             presentation,
                                             insight_title2,
@@ -1917,6 +1998,7 @@ def process_topic(topic: str,
                 try:
                     # Create minimal data card
                     data_card = build_data_card(src_df, metric, 'A2')
+                    _augment_data_card(data_card, 'A2', (family_resolution or {}).get('short_delta'), src_df)
                     
                     # Generate narrative anyway
                     narrative = llm_narrate(data_card, config)
@@ -1949,6 +2031,14 @@ def process_topic(topic: str,
                                     insight_title = sanitized_title
                                 else:
                                     insight_title = chart_title
+                            desc_title = _descriptive_chart_title(
+                                metric,
+                                chart_type,
+                                (family_resolution or {}).get('short_delta'),
+                                None,
+                            )
+                            if _needs_view_tag(insight_title, chart_type, (family_resolution or {}).get('short_delta')):
+                                insight_title = f"{desc_title} — {insight_title}" if insight_title else desc_title
                             add_insight_slide(
                                 presentation,
                                 insight_title,

--- a/narrate.py
+++ b/narrate.py
@@ -59,7 +59,10 @@ def build_data_card(df: pd.DataFrame,
         'trend': None,
         'volatility': None,
         'composition_base': composition_base,  # CRITICAL for A3
-        'key_facts': []
+        'key_facts': [],
+        'view': None,
+        'delta_type': None,
+        'split_by': None,
     }
     
     # Extract period range
@@ -364,6 +367,22 @@ FORMAT:
 }}
 """
 
+    view = (data_card.get('view') or '').lower()
+    delta_type = (data_card.get('delta_type') or '').upper()
+    split_by = (data_card.get('split_by') or '')
+
+    if view == 'trend':
+        prompt += "\nTITLE MUST explicitly reference a trend over time (use words like 'Trend' or 'Over time') and mention the time window."  # noqa: E501
+    elif view == 'composition':
+        prompt += "\nTITLE MUST call out the credit tier mix and specify which tiers gained or lost share."
+        if 'tier' in split_by.lower():
+            prompt += "\nALWAYS mention at least one credit tier (e.g., Prime, Near-Prime, Subprime) when describing the changes."  # noqa: E501
+    elif view == 'delta':
+        if delta_type in ('QOQ', 'YOY'):
+            prompt += f"\nTITLE MUST explicitly mention {delta_type} change and highlight the largest increases or decreases."
+        else:
+            prompt += "\nTITLE MUST call out period-over-period change and identify the strongest movers."
+
     if data_card.get('composition_base'):
         prompt += (
             f"\nIMPORTANT: Composition based on {data_card['composition_base']}"
@@ -624,15 +643,26 @@ def stub_llm_narrative(data_card: Dict[str, Any], config: SynthesisConfig,
         Stub narrative dictionary
     """
     metric = data_card.get('metric', 'Data')
-    chart_type = data_card.get('chart_type', '')
-    
-    # Generate deterministic narrative based on data
-    title = f"Analysis of {metric.replace('_', ' ').title()}"
-    
+    metric_label = metric.replace('_', ' ').title()
+    view = (data_card.get('view') or '').lower()
+    delta_type = (data_card.get('delta_type') or '').upper()
+
+    if view == 'composition':
+        title = f"{metric_label} — Credit tier mix"
+    elif view == 'delta':
+        if delta_type in ('QOQ', 'YOY'):
+            title = f"{metric_label} — {delta_type} change"
+        else:
+            title = f"{metric_label} — Period-over-period change"
+    elif view == 'trend':
+        title = f"{metric_label} — Trend over time"
+    else:
+        title = f"{metric_label} — Performance overview"
+
     bullets = []
     if data_card.get('latest_value') is not None and data_card.get('earliest_value') is not None:
         bullets.append(f"Current value: {data_card['latest_value']}, initial: {data_card['earliest_value']}")
-    
+
     if data_card.get('trend_direction'):
         bullets.append(f"Trend shows {data_card['trend_direction']} movement")
     
@@ -641,15 +671,30 @@ def stub_llm_narrative(data_card: Dict[str, Any], config: SynthesisConfig,
             if value is not None:
                 bullets.append(f"{delta_type}: {value}")
     
+    if view == 'composition':
+        dominant_fact = next(
+            (fact for fact in data_card.get('key_facts', []) if str(fact).lower().startswith('dominant tier')),
+            None,
+        )
+        tier_bullet = dominant_fact or "Credit tier mix shifts across tiers"
+        bullets.insert(0, tier_bullet)
+
     # Ensure at least 2 bullets
     while len(bullets) < 2:
         bullets.append(f"Pattern detected in {metric.replace('_', ' ')} data")
-    
+
     # Cap at 3 bullets
     bullets = bullets[:3]
-    
-    strapline = f"Key insight: {metric.replace('_', ' ')} shows measurable change over the period"
-    
+
+    if view == 'composition':
+        strapline = f"{metric_label} tiers show mix shifts across credit bands"
+    elif view == 'delta' and delta_type in ('QOQ', 'YOY'):
+        strapline = f"{metric_label} {delta_type} change spotlights leading movers"
+    elif view == 'trend':
+        strapline = f"{metric_label} trend highlights momentum over time"
+    else:
+        strapline = f"Key insight: {metric.replace('_', ' ')} shows measurable change over the period"
+
     return {
         'title': title[:NARRATIVE_LIMITS['title_max_chars']],
         'bullets': bullets,
@@ -700,6 +745,40 @@ def _validate_narrative(narrative: Dict[str, str], config: SynthesisConfig,
     if len(strapline) > NARRATIVE_LIMITS['strapline_max_chars']:
         issues.append(f"Strapline too long: {len(strapline)} > {NARRATIVE_LIMITS['strapline_max_chars']}")
     
+    view = (data_card or {}).get('view') if data_card else None
+    view_lower = str(view).lower() if view else ''
+    delta_type = (data_card or {}).get('delta_type') if data_card else None
+    delta_upper = str(delta_type).upper() if delta_type else ''
+    title_lower = title.lower()
+
+    if view_lower == 'trend':
+        if not any(token in title_lower for token in ('trend', 'over time')):
+            issues.append("Title must mention trend or over time")
+    elif view_lower == 'composition':
+        if not any(token in title_lower for token in ('tier', 'mix', 'composition')):
+            issues.append("Title must include credit tier mix")
+        tier_tokens = ('prime', 'near-prime', 'subprime', 'super-prime', 'deep subprime')
+        tier_present = any(token in title_lower for token in tier_tokens)
+        if not tier_present:
+            for bullet in bullets:
+                if isinstance(bullet, str) and any(token in bullet.lower() for token in tier_tokens):
+                    tier_present = True
+                    break
+        if not tier_present:
+            issues.append("Narrative must reference at least one credit tier")
+    elif view_lower == 'delta':
+        if delta_upper == 'QOQ':
+            tokens = ('qoq', 'quarter-over-quarter', 'q/q')
+            if not any(token in title_lower for token in tokens):
+                issues.append("Title must include QoQ phrasing")
+        elif delta_upper == 'YOY':
+            tokens = ('yoy', 'year-over-year', 'y/y')
+            if not any(token in title_lower for token in tokens):
+                issues.append("Title must include YoY phrasing")
+        else:
+            if not any(token in title_lower for token in ('change', 'delta', 'period-over-period')):
+                issues.append("Title must highlight period-over-period change")
+
     # STRICT NUMERIC GUARD: Check all numbers against data card
     if data_card:
         all_text = title + ' ' + ' '.join(bullets) + ' ' + strapline


### PR DESCRIPTION
## Summary
- attach view, delta, and split metadata to data cards so downstream prompts and fallbacks understand the active chart view and guard against generic titles
- enforce view-specific phrasing when constructing insight titles, including automatic descriptive prefixes whenever the LLM output omits trend, delta, or credit-tier language
- update narrative prompting, stubbed responses, and validation to require trend, QoQ/YoY, and tier terminology so credit-focused charts always mention credit tiers

## Testing
- python -m compileall main.py narrate.py

------
https://chatgpt.com/codex/tasks/task_e_68da09e8428c83279947d18187cbaf8e