### PR TITLE
Improve view-aware narrative guidance and QA

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,6 +173,55 @@ def _focus_suffix_from_period(period: Optional[str]) -> Optional[str]:
     return None
 
 
+def nudge_title_for_view(title: str, view: Optional[Dict[str, Any]], attempt: int = 1) -> str:
+    """Add a light-weight suffix to differentiate titles across views."""
+
+    if not title:
+        return title
+
+    base = str(title).strip()
+    trailing = ''
+    if base and base[-1] in '.!?':
+        trailing = base[-1]
+        base = base[:-1].rstrip()
+
+    view = view or {}
+    kind = (view.get('kind') or '').lower()
+    delta_type = (view.get('delta_type') or '').lower()
+
+    suffix_map = {
+        'composition': 'with tier shifts in focus',
+        'delta': {
+            'yoy': 'on a YoY basis',
+            'qoq': 'on a QoQ basis',
+            'mom': 'on a MoM basis',
+        }.get(delta_type, 'on a delta basis'),
+        'trend': 'tracking the overall trend',
+    }
+    suffix = suffix_map.get(kind, 'with this view in focus')
+
+    if suffix and suffix.lower() in base.lower():
+        alt_suffix_map = {
+            'composition': 'adding extra tier detail',
+            'delta': {
+                'yoy': 'reinforcing YoY shifts',
+                'qoq': 'reinforcing QoQ shifts',
+                'mom': 'reinforcing MoM shifts',
+            }.get(delta_type, 'highlighting delta nuances'),
+            'trend': 'with the timeline perspective',
+        }
+        suffix = alt_suffix_map.get(kind, f"from the {kind or 'alternate'} view")
+
+    if attempt > 1:
+        suffix = f"{suffix} ({attempt})"
+
+    candidate = f"{base}, {suffix}" if suffix else base
+    if trailing:
+        candidate = f"{candidate}{trailing}"
+
+    return candidate
+
+
 @dataclass
 class PipelineContext:
     """
@@ -194,7 +243,8 @@ class PipelineContext:
     slide_cache_keys: Set[str] = field(default_factory=set)
     slide_content_hashes: Set[str] = field(default_factory=set)
     sections_added: Set[str] = field(default_factory=set)
-    
+    metric_view_titles: Dict[str, List[str]] = field(default_factory=dict)
+
     def add_figure(self, fig_data: Dict[str, Any], chart_type: str):
         """Add a figure artifact with metadata."""
         self.figures.append(fig_data)
@@ -211,6 +261,29 @@ class PipelineContext:
     def add_narrative(self, narrative_data: Dict[str, Any]):
         """Add a narrative artifact."""
         self.narratives.append(narrative_data)
+
+    def register_view_title(self, metric: str, base_title: str, view: Optional[Dict[str, Any]]) -> str:
+        """Ensure titles per metric remain unique across views."""
+
+        if not base_title:
+            return base_title
+
+        history = self.metric_view_titles.setdefault(metric, [])
+        candidate = base_title
+        attempt = 0
+
+        while candidate in history and attempt < 5:
+            attempt += 1
+            candidate = nudge_title_for_view(base_title, view, attempt=attempt)
+
+        if candidate in history:
+            view_label = (view or {}).get('kind') or 'view'
+            candidate = f"{base_title} ({view_label})"
+            if candidate in history:
+                candidate = f"{base_title} ({view_label} {len(history) + 1})"
+
+        history.append(candidate)
+        return candidate
 
 
 def _delinquency_headline(
@@ -1157,11 +1230,30 @@ def process_topic(topic: str,
                 if chart_type == 'A3':
                     composition_base = select_composition_base(src_df, metric)
                 
-                data_card = build_data_card(src_df, metric, chart_type, composition_base=composition_base)
-                
+                delta_for_card = None
+                if chart_type == 'A4':
+                    if family_resolution and family_resolution.get('short_delta'):
+                        delta_for_card = family_resolution.get('short_delta')
+                    else:
+                        delta_for_card = 'yoy'
+                data_card = build_data_card(
+                    src_df,
+                    metric,
+                    chart_type,
+                    composition_base=composition_base,
+                    delta_type=delta_for_card,
+                )
+
                 # Generate narrative
                 narrative = llm_narrate(data_card, config)
                 results['narratives_generated'] += 1
+
+                view_context = data_card.get('view')
+                narrative_title = (narrative.get('title') or '').strip()
+                if narrative_title:
+                    adjusted_title = ctx.register_view_title(metric, narrative_title, view_context)
+                    if adjusted_title != narrative_title:
+                        narrative['title'] = adjusted_title
                 
                 # QC check for avg_acct_per_cnsmr contradictions
                 if 'avg_acct_per_cnsmr' in metric.lower():
@@ -1260,6 +1352,8 @@ def process_topic(topic: str,
                 # Track narrative artifact
                 ctx.add_narrative({
                     'metric': metric,
+                    'chart_type': chart_type,
+                    'view': data_card.get('view'),
                     'title': narrative.get('title', ''),
                     'bullets': narrative.get('bullets', []),
                     'strapline': narrative.get('strapline', '')
@@ -1411,6 +1505,13 @@ def process_topic(topic: str,
                                 trend_chart_title = f"{base_phrase} Trend"
                                 trend_card = build_data_card(prepared_trend, avail[0], 'A2')
                                 trend_narrative = llm_narrate(trend_card, config)
+                                trend_title = (trend_narrative.get('title') or '').strip()
+                                if trend_title:
+                                    adjusted = ctx.register_view_title(
+                                        avail[0], trend_title, trend_card.get('view')
+                                    )
+                                    if adjusted != trend_title:
+                                        trend_narrative['title'] = adjusted
                                 add_chart_slide(
                                     presentation,
                                     delinquency_headline,
@@ -1430,6 +1531,8 @@ def process_topic(topic: str,
                                 })
                                 ctx.add_narrative({
                                     'metric': avail[0],
+                                    'chart_type': 'A2',
+                                    'view': trend_card.get('view'),
                                     'title': trend_narrative.get('title', ''),
                                     'bullets': trend_narrative.get('bullets', []),
                                     'strapline': trend_narrative.get('strapline', ''),
@@ -1465,6 +1568,13 @@ def process_topic(topic: str,
                                     composition_base='credit_tier',
                                 )
                                 severity_narrative = llm_narrate(severity_card, config)
+                                severity_title = (severity_narrative.get('title') or '').strip()
+                                if severity_title:
+                                    adjusted = ctx.register_view_title(
+                                        avail[0], severity_title, severity_card.get('view')
+                                    )
+                                    if adjusted != severity_title:
+                                        severity_narrative['title'] = adjusted
                                 add_chart_slide(
                                     presentation,
                                     split_title,
@@ -1484,6 +1594,8 @@ def process_topic(topic: str,
                                 })
                                 ctx.add_narrative({
                                     'metric': avail[0],
+                                    'chart_type': 'A3',
+                                    'view': severity_card.get('view'),
                                     'title': severity_narrative.get('title', ''),
                                     'bullets': severity_narrative.get('bullets', []),
                                     'strapline': severity_narrative.get('strapline', ''),
@@ -1786,8 +1898,28 @@ def process_topic(topic: str,
                         }
                         ctx.add_figure(figure_data, yoy_chart_type)
 
-                        data_card2 = build_data_card(src_df, metric, yoy_chart_type)
+                        data_card2 = build_data_card(
+                            src_df,
+                            metric,
+                            yoy_chart_type,
+                            delta_type=delta_type,
+                        )
                         narrative2 = llm_narrate(data_card2, config)
+                        view_context2 = data_card2.get('view')
+                        title2 = (narrative2.get('title') or '').strip()
+                        if title2:
+                            adjusted2 = ctx.register_view_title(metric, title2, view_context2)
+                            if adjusted2 != title2:
+                                narrative2['title'] = adjusted2
+
+                        ctx.add_narrative({
+                            'metric': metric,
+                            'chart_type': yoy_chart_type,
+                            'view': view_context2,
+                            'title': narrative2.get('title', ''),
+                            'bullets': narrative2.get('bullets', []),
+                            'strapline': narrative2.get('strapline', ''),
+                        })
 
                         # Compute headline for YoY
                         from synthesis_agent.utils import pretty_label, fmt_value
@@ -1917,11 +2049,18 @@ def process_topic(topic: str,
                 try:
                     # Create minimal data card
                     data_card = build_data_card(src_df, metric, 'A2')
-                    
+
                     # Generate narrative anyway
                     narrative = llm_narrate(data_card, config)
                     results['narratives_generated'] += 1
-                    
+
+                    fallback_view = data_card.get('view')
+                    fallback_title = (narrative.get('title') or '').strip()
+                    if fallback_title:
+                        adjusted = ctx.register_view_title(metric, fallback_title, fallback_view)
+                        if adjusted != fallback_title:
+                            narrative['title'] = adjusted
+
                     # Add slide without image (with deduplication check)
                     if presentation and not ctx.dry_run:
                         # Check for duplicate content
@@ -1975,6 +2114,15 @@ def process_topic(topic: str,
                             logger.info(f"Skipping duplicate narrative-only slide for {metric}")
                         logger.info(f"Added narrative-only slide for {metric} after chart failure")
                         results['slides_created'] += 1
+
+                    ctx.add_narrative({
+                        'metric': metric,
+                        'chart_type': 'A2',
+                        'view': fallback_view,
+                        'title': narrative.get('title', ''),
+                        'bullets': narrative.get('bullets', []),
+                        'strapline': narrative.get('strapline', ''),
+                    })
                 except Exception as narr_e:
                     logger.error(f"Also failed to generate narrative for {metric}: {narr_e}")
         
@@ -2449,7 +2597,7 @@ def main():
     coverage_ledger.print_summary()
     
     # Validate plan consistency
-    is_valid, issues = validate_plan_consistency(coverage_ledger, config)
+    is_valid, issues = validate_plan_consistency(coverage_ledger, config, ctx.narratives)
     if not is_valid:
         logger.warning(f"Plan validation issues: {issues}")
     

--- a/narrate.py
+++ b/narrate.py
@@ -32,7 +32,8 @@ def build_data_card(df: pd.DataFrame,
                    metric: str,
                    chart_type: str,
                    period_col: str = 'period',
-                   composition_base: Optional[str] = None) -> Dict[str, Any]:
+                   composition_base: Optional[str] = None,
+                   delta_type: Optional[str] = None) -> Dict[str, Any]:
     """
     Build data card with all facts for LLM.
     CRITICAL: Include composition_base for A3 charts.
@@ -60,6 +61,24 @@ def build_data_card(df: pd.DataFrame,
         'volatility': None,
         'composition_base': composition_base,  # CRITICAL for A3
         'key_facts': []
+    }
+
+    view_kind = 'trend'
+    split_dim = None
+    normalized_delta = (delta_type or '').lower() or None
+
+    if chart_type == 'A3':
+        view_kind = 'composition'
+        split_dim = composition_base or 'credit_tier'
+    elif chart_type == 'A4':
+        view_kind = 'delta'
+    elif chart_type not in {'A2', 'trend'}:
+        view_kind = chart_type.lower()
+
+    card['view'] = {
+        'kind': view_kind,
+        'split_dim': split_dim,
+        'delta_type': normalized_delta,
     }
     
     # Extract period range
@@ -126,7 +145,7 @@ def build_data_card(df: pd.DataFrame,
     # Add chart-specific facts
     if chart_type == 'A3' and composition_base:
         card['key_facts'].append(f"Composition based on {composition_base}")
-    
+
     if chart_type == 'A4':
         # Look for delta columns
         delta_cols = [c for c in df.columns if metric in c and any(d in c for d in ['_yoy_pct', '_qoq_pct', '_mom_pct'])]
@@ -147,11 +166,29 @@ def build_data_card(df: pd.DataFrame,
                 value = df.loc[latest_idx, tier] if latest_idx >= 0 else df[tier].iloc[-1]
                 if pd.notna(value):
                     tier_values[tier] = value
-        
+
         if tier_values:
+            def _format_tier_value(v: float) -> str:
+                if pd.isna(v):
+                    return "—"
+                if abs(v) <= 1.2:
+                    return fmt_percent(v, decimals=0)
+                return f"{float(v):.1f}"
+
+            def _clean_tier_name(name: str) -> str:
+                text = str(name or "").replace('_', ' ').strip()
+                return text.title() if text else "Tier"
+
+            if chart_type == 'A3':
+                ordered = sorted(tier_values.items(), key=lambda item: item[1], reverse=True)
+                top_pairs = ordered[:3]
+                mix_parts = [f"{_clean_tier_name(tier)} {_format_tier_value(val)}" for tier, val in top_pairs]
+                if mix_parts:
+                    card['key_facts'].append(f"Latest tier mix: {', '.join(mix_parts)}")
             # Find dominant tier
             dominant_tier = max(tier_values, key=tier_values.get)
-            card['key_facts'].append(f"Dominant tier: {dominant_tier} ({tier_values[dominant_tier]:.1f})")
+            dominant_value = _format_tier_value(tier_values[dominant_tier])
+            card['key_facts'].append(f"Dominant tier: {_clean_tier_name(dominant_tier)} ({dominant_value})")
     
     logger.info(f"Built data card for {metric}/{chart_type} with {len(card['key_facts'])} facts")
     return card
@@ -363,6 +400,26 @@ FORMAT:
   "strapline": "concise key insight under 140 chars"
 }}
 """
+
+    view = data_card.get('view', {}) or {}
+    view_kind = (view.get('kind') or '').lower()
+
+    if view_kind == 'trend':
+        prompt += "\nVIEW CONTEXT: This chart shows an over-time trend.\nWrite a natural, one-sentence title summarizing how the metric moved across the shown period range.\nFavor verbs like “softened”, “stabilized”, “accelerated”, “rebounded”. Avoid fragments."
+    elif view_kind == 'composition':
+        prompt += "\nVIEW CONTEXT: This chart shows the metric split by credit tiers (composition).\nTitle MUST naturally mention tiers and who leads or lags (e.g., “Prime+ leads; Subprime eases”).\nIn bullets, call out the top 2–3 tiers and whether each rose, fell, or held steady versus the comparison point.\nUse concise tier names (Super Prime, Prime+, Prime, Near-Prime, Subprime) if present."
+    elif view_kind == 'delta':
+        delta_window = (view.get('delta_type') or '').lower()
+        window_display = {
+            'qoq': 'QoQ',
+            'yoy': 'YoY',
+            'mom': 'MoM',
+        }.get(delta_window, delta_window.upper() if delta_window else 'QoQ')
+        prompt += (
+            f"\nVIEW CONTEXT: This chart shows change versus a comparison period. The window is: {window_display}."
+            "\nTitle MUST naturally state the window (e.g., “Balances rose YoY, led by Prime+”)."
+            "\nIn bullets, highlight the largest increase and largest decrease (if any) and whether the move is meaningful."
+        )
 
     if data_card.get('composition_base'):
         prompt += (

--- a/validate_plan.py
+++ b/validate_plan.py
@@ -5,7 +5,7 @@ Implements CoverageLedger, product gating, and delta base availability checks.
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 import pandas as pd
 import numpy as np
 
@@ -34,6 +34,22 @@ logger = setup_logging("validate_plan")
 
 # Constants for long-form tier detection
 LONG_FORM_TIER_CANDIDATES = ["score_curr_tier", "score_tier", "tier", "risk_tier", "score_band"]
+TIER_TOKEN_CANDIDATES = [
+    'super prime',
+    'superprime',
+    'prime+',
+    'prime plus',
+    'prime ',
+    ' prime',
+    'near-prime',
+    'near prime',
+    'subprime',
+    'sub-prime',
+]
+DELTA_TITLE_TOKENS = {
+    'yoy': ['yoy', 'year-over-year', 'year over year'],
+    'qoq': ['qoq', 'quarter-over-quarter', 'quarter over quarter'],
+}
 
 
 @dataclass
@@ -467,7 +483,8 @@ def apply_fallback_strategy(df: pd.DataFrame,
 
 
 def validate_plan_consistency(coverage_ledger: CoverageLedger,
-                             config: SynthesisConfig) -> Tuple[bool, List[str]]:
+                             config: SynthesisConfig,
+                             narratives: Optional[List[Dict[str, Any]]] = None) -> Tuple[bool, List[str]]:
     """
     Validate overall plan consistency.
     
@@ -499,5 +516,29 @@ def validate_plan_consistency(coverage_ledger: CoverageLedger,
             if df[chart_type].str.contains('✓').sum() == 0:
                 logger.warning(f"No {chart_type} charts in plan")
     
+    if narratives:
+        for narrative in narratives:
+            view = (narrative.get('view') or {}) if isinstance(narrative, dict) else {}
+            view_kind = (view.get('kind') or '').lower()
+            title = str(narrative.get('title', '') or '')
+            bullets = narrative.get('bullets') if isinstance(narrative.get('bullets'), list) else []
+            metric_name = narrative.get('metric', 'unknown metric')
+
+            if view_kind == 'composition':
+                combined = " ".join([title] + [str(b) for b in bullets]).lower()
+                normalized = combined.replace(';', ' ').replace('/', ' ').replace(',', ' ').replace('.', ' ')
+                if not any(token in normalized for token in TIER_TOKEN_CANDIDATES):
+                    logger.warning(
+                        f"Composition narrative for {metric_name} lacks tier references in title or bullets"
+                    )
+            elif view_kind == 'delta':
+                delta_type = (view.get('delta_type') or '').lower()
+                tokens = DELTA_TITLE_TOKENS.get(delta_type, [])
+                if tokens and not any(token in title.lower() for token in tokens):
+                    window_label = delta_type.upper()
+                    logger.warning(
+                        f"Delta narrative for {metric_name} missing {window_label} cue in title"
+                    )
+
     is_valid = len(issues) == 0
     return is_valid, issues


### PR DESCRIPTION
## Summary
- annotate data cards with view metadata and add tier mix facts to support tier-focused narratives
- tailor insight prompts and metric title nudges for trend, composition, and delta views while de-duplicating titles per metric
- extend plan validation to flag missing tier or QoQ/YoY language in generated narratives

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dbb060b8908327b429e235752042e6